### PR TITLE
Update .Net tutorial for latest version of Confluent.Kafka

### DIFF
--- a/quickstart/dotnet/EventHubsForKafkaSample/EventHubsForKafkaSample.csproj
+++ b/quickstart/dotnet/EventHubsForKafkaSample/EventHubsForKafkaSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="0.11.5" />
+    <PackageReference Include="Confluent.Kafka" Version="1.1.0" />
     <!-- Version="1.0.0-beta" />-->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" /> <!--Version="4.5.0" />-->
   </ItemGroup>

--- a/quickstart/dotnet/EventHubsForKafkaSample/Worker.cs
+++ b/quickstart/dotnet/EventHubsForKafkaSample/Worker.cs
@@ -56,6 +56,7 @@ namespace EventHubsForKafkaSample
                 SaslPassword = connStr,
                 SslCaLocation = cacertlocation,
                 GroupId = consumergroup,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
                 BrokerVersionFallback = "1.0.0",        //Event Hubs for Kafka Ecosystems supports Kafka v1.0+, a fallback to an older API will fail
                 //Debug = "security,broker,protocol"    //Uncomment for librdkafka debugging information
             };

--- a/quickstart/dotnet/EventHubsForKafkaSample/Worker.cs
+++ b/quickstart/dotnet/EventHubsForKafkaSample/Worker.cs
@@ -6,11 +6,9 @@
 //Original Confluent sample modified for use with Azure Event Hubs for Apache Kafka Ecosystems
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 
 namespace EventHubsForKafkaSample
 {
@@ -20,23 +18,23 @@ namespace EventHubsForKafkaSample
         {
             try
             {
-                var config = new Dictionary<string, object> {
-                    { "bootstrap.servers", brokerList },
-                    { "security.protocol", "SASL_SSL" },
-                    { "sasl.mechanism", "PLAIN" },
-                    { "sasl.username", "$ConnectionString" },
-                    { "sasl.password", connStr },
-                    { "ssl.ca.location", cacertlocation },
-                    //{ "debug", "security,broker,protocol" }       //Uncomment for librdkafka debugging information
+                var config = new ProducerConfig
+                {
+                    BootstrapServers = brokerList,
+                    SecurityProtocol = SecurityProtocol.SaslSsl,
+                    SaslMechanism = SaslMechanism.Plain,
+                    SaslUsername = "$ConnectionString",
+                    SaslPassword = connStr,
+                    SslCaLocation = cacertlocation,
+                    //Debug = "security,broker,protocol"        //Uncomment for librdkafka debugging information
                 };
-
-                using (var producer = new Producer<long, string>(config, new LongSerializer(), new StringSerializer(Encoding.UTF8)))
+                using (var producer = new ProducerBuilder<long, string>(config).SetKeySerializer(Serializers.Int64).SetValueSerializer(Serializers.Utf8).Build())
                 {
                     Console.WriteLine("Sending 10 messages to topic: " + topic + ", broker(s): " + brokerList);
                     for (int x = 0; x < 10; x++)
                     {
                         var msg = string.Format("Sample message #{0} sent at {1}", x, DateTime.Now.ToString("yyyy-MM-dd_HH:mm:ss.ffff"));
-                        var deliveryReport = await producer.ProduceAsync(topic, DateTime.UtcNow.Ticks, msg);
+                        var deliveryReport = await producer.ProduceAsync(topic, new Message<long, string> { Key = DateTime.UtcNow.Ticks, Value = msg });
                         Console.WriteLine(string.Format("Message {0} sent (value: '{1}')", x, msg));
                     }
                 }
@@ -49,40 +47,45 @@ namespace EventHubsForKafkaSample
 
         public static void Consumer(string brokerList, string connStr, string consumergroup, string topic, string cacertlocation)
         {
-            var config = new Dictionary<string, object> {
-                    { "bootstrap.servers", brokerList },
-                    { "security.protocol","SASL_SSL" },
-                    { "sasl.mechanism","PLAIN" },
-                    { "sasl.username", "$ConnectionString" },
-                    { "sasl.password", connStr },
-                    { "ssl.ca.location", cacertlocation },
-                    { "group.id", consumergroup },
-                    { "request.timeout.ms", 60000 },
-                    { "broker.version.fallback", "1.0.0" },         //Event Hubs for Kafka Ecosystems supports Kafka v1.0+, 
-                                                                    //a fallback to an older API will fail
-                    //{ "debug", "security,broker,protocol" }       //Uncomment for librdkafka debugging information
-                };
-
-            using (var consumer = new Consumer<long, string>(config, new LongDeserializer(), new StringDeserializer(Encoding.UTF8)))
+            var config = new ConsumerConfig
             {
-                consumer.OnMessage += (_, msg)
-                  => Console.WriteLine($"Received: '{msg.Value}'");
+                BootstrapServers = brokerList,
+                SecurityProtocol = SecurityProtocol.SaslSsl,
+                SaslMechanism = SaslMechanism.Plain,
+                SaslUsername = "$ConnectionString",
+                SaslPassword = connStr,
+                SslCaLocation = cacertlocation,
+                GroupId = consumergroup,
+                BrokerVersionFallback = "1.0.0",        //Event Hubs for Kafka Ecosystems supports Kafka v1.0+, a fallback to an older API will fail
+                //Debug = "security,broker,protocol"    //Uncomment for librdkafka debugging information
+            };
 
-                consumer.OnError += (_, error)
-                  => Console.WriteLine($"Error: {error}");
+            using (var consumer = new ConsumerBuilder<long, string>(config).SetKeyDeserializer(Deserializers.Int64).SetValueDeserializer(Deserializers.Utf8).Build())
+            {
+                CancellationTokenSource cts = new CancellationTokenSource();
+                Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
-                consumer.OnConsumeError += (_, msg)
-                  => Console.WriteLine($"Consume error ({msg.TopicPartitionOffset}): {msg.Error}");
+                consumer.Subscribe(topic);
 
                 Console.WriteLine("Consuming messages from topic: " + topic + ", broker(s): " + brokerList);
-                consumer.Subscribe(topic);
 
                 while (true)
                 {
-                    consumer.Poll(TimeSpan.FromMilliseconds(1000));
+                    try
+                    {
+                        var msg = consumer.Consume(cts.Token);
+                        Console.WriteLine($"Received: '{msg.Value}'");
+                    }
+                    catch (ConsumeException e)
+                    {
+                        Console.WriteLine($"Consume error: {e.Error.Reason}");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"Error: {e.Message}");
+                    }
                 }
             }
-
         }
     }
 }

--- a/quickstart/dotnet/README.md
+++ b/quickstart/dotnet/README.md
@@ -10,7 +10,7 @@ If you don't have an Azure subscription, create a [free account](https://azure.m
 
 In addition:
 
-* [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/)
+* [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
 * [Git](https://www.git-scm.com/downloads)
 
 ## Create an Event Hubs namespace
@@ -39,7 +39,7 @@ cd azure-event-hubs-for-kafka/quickstart/dotnet
 
 Use the NuGet Package Manager UI (or Package Manager Console) to install the Confluent.Kafka package. More detailed instructions can be found [here](https://github.com/confluentinc/confluent-kafka-dotnet#referencing). 
 
-**This tutorial uses Confluent.Kafka v0.11 - using v1.0-beta will cause compilation errors.**
+**This tutorial uses Confluent.Kafka v1.1.0**
 
 ## Update App.config
 
@@ -47,7 +47,7 @@ Update the values of the `EH_FQDN` and `EH_CONNECTION_STRING` in `App.config` to
 
 ## Run the application
 
-Run the application in VS2017 and watch it go! If the Kafka-enabled Event Hub has incoming events, then the consumer should now begin receiving events from the topic set in `App.config`. 
+Run the application in VS2019 and watch it go! If the Kafka-enabled Event Hub has incoming events, then the consumer should now begin receiving events from the topic set in `App.config`. 
 
 **NOTE**: Since Kafka's default for an unknown consumer group is to read from the *latest* offset, the first time you run the consumer will not receive any events from this application's producer. This is because the producer sends its messages before the consumer polls in this application. To remedy this, either run the application several times with the same consumer group (so that the consumer group's offset will be known to the broker), set Kafka's [`auto.offset.reset` consumer config](https://kafka.apache.org/documentation/#newconsumerconfigs) to `earliest`, or use an external producer and produce simultaneously.
 


### PR DESCRIPTION
This update switch Confluent.Kafka from v. 0.11.5 to v. 1.1.0. As in 1.1.0 object model has been changed, Worker.cs has been rewritten.
This Confluent.Kafka v. 1.1.0 supports .NetStabdard 1.3, this code can be recompiled for .Net Classic and other, that supports .NetStabdard 1.3