### PR TITLE
fix documentation

### DIFF
--- a/quickstart/kafka-cli/README.md
+++ b/quickstart/kafka-cli/README.md
@@ -92,17 +92,13 @@ Update the `password` field in the `jaas.conf` with the primary connection strin
 > **Please do not remove** the trailing `;` in the `password` field of the `jaas.conf` file
 
     KafkaClient {
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="$ConnectionString"
-        password=enter-connection-string-here;
+        org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="enter-connection-string-here";
     };
 
 For example:
 
     KafkaClient {
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="$ConnectionString"
-        password=Endpoint=sb://foobar-eventhub-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=Nbaz0D42MT7qwerty6D/W51ao42r6EJuxR/zEqwerty=;
+        org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password=Endpoint="sb://foobar-eventhub-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=Nbaz0D42MT7qwerty6D/W51ao42r6EJuxR/zEqwerty=";
     };
 
 ## Connect to Event Hubs using Kafka CLI

--- a/quickstart/kafka-cli/jaas.conf
+++ b/quickstart/kafka-cli/jaas.conf
@@ -1,5 +1,3 @@
-KafkaClient {
-    org.apache.kafka.common.security.plain.PlainLoginModule required
-    username="$ConnectionString"
-    password=;
+KafkaClient { 
+    org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="";
 };


### PR DESCRIPTION
Description
===========
<Describe the issue here>
The documentation is incorrect.
https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/quickstart/kafka-cli/README.md

How to reproduce
================
<How to reproduce the issue, or remove section if not relevant>
### jaas.conf
```
# 3 lines and not quoted in password part
KafkaClient { 
    org.apache.kafka.common.security.plain.PlainLoginModule required 
    username="$ConnectionString" 
    password=Endpoint=sb://...;
};
```
Then syntax error happens
```
$ $KAFKA_INSTALL_HOME/bin/kafka-console-consumer.sh --topic $EVENT_HUB_NAME --bootstrap-server $EVENT_HUBS_NAMESPACE.servicebus.windows.net:9093 --consumer.config client_common.properties
configfile: reading file: ./github.com/Azure/azure-event-hubs-for-kafka/quickstart/kafka-cli/jaas.conf
configparser: 	Reading next config entry: KafkaClient
[2020-02-13 19:19:31,655] ERROR Unknown error when running consumer:  (kafka.tools.ConsoleConsumer$)
org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:820)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:666)
	at kafka.tools.ConsoleConsumer$.run(ConsoleConsumer.scala:67)
	at kafka.tools.ConsoleConsumer$.main(ConsoleConsumer.scala:54)
	at kafka.tools.ConsoleConsumer.main(ConsoleConsumer.scala)
Caused by: java.lang.SecurityException: java.io.IOException: Configuration Error:
	Line 2: expected [option key]
```

When it changed as 
```
# 1 line with password quoted
KafkaClient { 
    org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://...";
};
```
It works. 