### PR TITLE
Add idle connection and metadata age for load balancer timeout

### DIFF
--- a/tutorials/mirror-maker/mirror-eventhub.config
+++ b/tutorials/mirror-maker/mirror-eventhub.config
@@ -6,3 +6,7 @@ client.id=mirror_maker_producer
 sasl.mechanism=PLAIN
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX";
+
+# to avoid Azure load balancer (4 minutes timeout) closing idle connections
+connections.max.idle.ms=180000
+metadata.max.age.ms=180000


### PR DESCRIPTION
As per discussion #105, commit https://github.com/Azure/azure-event-hubs-for-kafka/commit/f796795cf80046e932e5fa1a4cb8306157ff11c8 and documentation https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md, the idle connections timeout, and metadata age should be set in the producer part.