### PR TITLE
Fix double quotation into quickstart kafka-cli readme jaas.conf example

### DIFF
--- a/quickstart/kafka-cli/README.md
+++ b/quickstart/kafka-cli/README.md
@@ -98,7 +98,7 @@ Update the `password` field in the `jaas.conf` with the primary connection strin
 For example:
 
     KafkaClient {
-        org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password=Endpoint="sb://foobar-eventhub-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=Nbaz0D42MT7qwerty6D/W51ao42r6EJuxR/zEqwerty=";
+        org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://foobar-eventhub-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=Nbaz0D42MT7qwerty6D/W51ao42r6EJuxR/zEqwerty=";
     };
 
 ## Connect to Event Hubs using Kafka CLI


### PR DESCRIPTION
The double quotes in the jaas.conf example(quickstart/kafka-cli/README.md) were misaligned, so I fixed it.