### PR TITLE
Removed duplicate key from filebeat tutorial

### DIFF
--- a/tutorials/filebeat/README.md
+++ b/tutorials/filebeat/README.md
@@ -47,7 +47,6 @@ output.kafka:
   ssl.enabled: true
   compression: none
   max_message_bytes: 1000000
-  required_acks: 1
   partition.round_robin:
     reachable_only: true
 logging.level: debug


### PR DESCRIPTION
Readme for the filebeat tutorial contained duplicate required_acks in example