### PR TITLE
Add mirror maker sample with OAUTHBEARER

### DIFF
--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -35,11 +35,11 @@ Learn more about [Azure EventHubs Role Based Access Control](https://docs.micros
 
 ## Clone the example project
 
-Now that you have a Kafka-enabled Event Hubs connection string, clone the Azure Event Hubs for Kafka repository and navigate to the `tutorials/mirror-maker` subfolder:
+Now that you have a Kafka-enabled Event Hubs connection string, clone the Azure Event Hubs for Kafka repository and navigate to the `tutorials/oauth/mirror-maker` subfolder:
 
 ```bash
 git clone https://github.com/Azure/azure-event-hubs-for-kafka.git
-cd azure-event-hubs-for-kafka/tutorials/mirror-maker
+cd azure-event-hubs-for-kafka/tutorials/oauth/mirror-maker
 ```
 
 ## Set up a Kafka cluster

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -61,7 +61,7 @@ Kafka clients need to be configured in a way that they can authenticate with Azu
 
 ### Package authentication handler into a jar
 
-Generate the JAR by running mvn command:
+Generate the JAR package by running mvn command below:
 
 ```bash
 mvn clean package

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -111,8 +111,9 @@ sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginMo
 sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
 ```
 
-### Copy auth handler jar to Kafka library folder
-We need Kafka mirror-maker client to load our authenticaion handler library built in the previous steps. Copy the jar file from build location to Kafka library folder. Please note that there may be other libraries missing under Kafka libraries to run the authentication handler. Copy those dependencies as well if mirror-maker reports about missing libraries.
+### Copy auth handler jar pacjage to Kafka library folder
+
+You will need Kafka mirror-maker client to load authentication handler library built in the previous steps. Copy the jar file from build location to Kafka library folder. Please note that there may be other libraries missing under Kafka libraries to run your authentication handler. Copy those dependencies as well if mirror-maker reports about any missing libraries.
 
 ### Run MirrorMaker
 

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -96,7 +96,7 @@ client.id=mirror_maker_consumer
 
 #### Producer Configuration
 
-Now update the producer config file `mirror-eventhub.config`, which tells MirrorMaker to send the duplicated (or "mirrored") data to the Event Hubs service. Specifically change `bootstrap.servers`, `sasl.mechanism`, `sasl.jaas.config`, and `sasl.login.callback.handler.class` to point to your Event Hubs Kafka endpoint. The Event Hubs service requires secure (SASL) communication, which is achieved by setting the last three properties in the configuration below. 
+Now update the producer config file `mirror-eventhub.config`, which tells MirrorMaker to send the duplicated (or "mirrored") data to the Event Hubs service. Specifically change `bootstrap.servers` to point to your Event Hubs Kafka endpoint.
 
 ##### mirror-eventhub.config
 
@@ -105,10 +105,14 @@ bootstrap.servers=mynamespace.servicebus.windows.net:9093
 client.id=mirror_maker_producer
 
 #Required for Event Hubs
-sasl.mechanism=PLAIN
 security.protocol=SASL_SSL
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX";
+sasl.mechanism=OAUTHBEARER
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
 ```
+
+### Copy auth handler jar to Kafka library folder
+We need Kafka mirror-maker client to load our authenticaion handler library built in the previous steps. Copy the jar file from build location to Kafka library folder. Please note that there may be other libraries missing under Kafka libraries to run the authentication handler. Copy those dependencies as well if mirror-maker reports about missing libraries.
 
 ### Run MirrorMaker
 

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -1,0 +1,94 @@
+# Using Apache Kafka's MirrorMaker with Event Hubs for Apache Kafka Ecosystems
+
+![MirrorMaker Diagram](./mirror-maker-graphic.PNG) 
+
+One major consideration for modern cloud scale apps is being able to update, improve, and change infrastructure without interrupting service. In this tutorial, we show how a Kafka-enabled Event Hub and Kafka MirrorMaker can integrate an existing Kafka pipeline into Azure by "mirroring" the Kafka input stream in the Event Hub service. 
+
+## Prerequisites
+
+To complete this tutorial, make sure you have:
+
+* An Azure subscription. If you do not have one, create a [free account](https://azure.microsoft.com/free/?ref=microsoft.com&utm_source=microsoft.com&utm_medium=docs&utm_campaign=visualstudio) before you begin.
+* [Java Development Kit (JDK) 1.7+](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+    * On Ubuntu, run `apt-get install default-jdk` to install the JDK.
+    * Be sure to set the JAVA_HOME environment variable to point to the folder where the JDK is installed.
+* [Download](http://maven.apache.org/download.cgi) and [install](http://maven.apache.org/install.html) a Maven binary archive
+    * On Ubuntu, you can run `apt-get install maven` to install Maven.
+* [Git](https://www.git-scm.com/downloads)
+    * On Ubuntu, you can run `sudo apt-get install git` to install Git.
+
+## Create an Event Hubs namespace
+
+An Event Hubs namespace is required to send or receive from any Event Hubs service. See [Create a Kafka-enabled Event Hub](https://docs.microsoft.com/azure/event-hubs/event-hubs-create-kafka-enabled) for instructions on getting an Event Hubs Kafka endpoint. Make sure to copy the Event Hubs connection string for later use.
+
+### FQDN
+
+For these samples, you will need the connection string from the portal as well as the FQDN that points to your Event Hub namespace. **The FQDN can be found within your connection string as follows**:
+
+`Endpoint=sb://`**`mynamespace.servicebus.windows.net`**`/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX`
+
+If your Event Hubs namespace is deployed on a non-Public cloud, your domain name may differ (e.g. \*.servicebus.chinacloudapi.cn, \*.servicebus.usgovcloudapi.net, or \*.servicebus.cloudapi.de).
+
+## Clone the example project
+
+Now that you have a Kafka-enabled Event Hubs connection string, clone the Azure Event Hubs for Kafka repository and navigate to the `tutorials/mirror-maker` subfolder:
+
+```bash
+git clone https://github.com/Azure/azure-event-hubs-for-kafka.git
+cd azure-event-hubs-for-kafka/tutorials/mirror-maker
+```
+
+## Set up a Kafka cluster
+
+Use the [Kafka quickstart guide](https://kafka.apache.org/quickstart) to set up a cluster with the desired settings (or use an existing Kafka cluster).
+
+## Kafka MirrorMaker
+
+Kafka MirrorMaker allows for the "mirroring" of a stream. Given source and destination Kafka clusters, MirrorMaker will ensure any messages sent to the source cluster will be received by both the source *and* destination clusters. In this example, we'll show how to mirror a source Kafka cluster with a destination Kafka-enabled Event Hub. This scenario can be used to send data from an existing Kafka pipeline to Event Hubs without interrupting the flow of data. 
+
+Check out the [Kafka Mirroring/MirrorMaker Guide](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330) for more detailed information on Kafka MirrorMaker.
+
+### Configuration
+
+To configure Kafka MirrorMaker, we'll give it a Kafka cluster as its consumer/source and a Kafka-enabled Event Hub as its producer/destination.
+
+#### Consumer Configuration
+
+Update the consumer configuration file `source-kafka.config`, which tells MirrorMaker the properties of the source Kafka cluster.
+
+##### source-kafka.config
+
+```config
+bootstrap.servers={SOURCE.KAFKA.IP.ADDRESS1}:{SOURCE.KAFKA.PORT1},{SOURCE.KAFKA.IP.ADDRESS2}:{SOURCE.KAFKA.PORT2},etc
+group.id=example-mirrormaker-group
+exclude.internal.topics=true
+client.id=mirror_maker_consumer
+```
+
+#### Producer Configuration
+
+Now update the producer config file `mirror-eventhub.config`, which tells MirrorMaker to send the duplicated (or "mirrored") data to the Event Hubs service. Specifically change `bootstrap.servers` and `sasl.jaas.config` to point to your Event Hubs Kafka endpoint. The Event Hubs service requires secure (SASL) communication, which is achieved by setting the last three properties in the configuration below. 
+
+##### mirror-eventhub.config
+
+```config
+bootstrap.servers=mynamespace.servicebus.windows.net:9093
+client.id=mirror_maker_producer
+
+#Required for Event Hubs
+sasl.mechanism=PLAIN
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX";
+```
+
+### Run MirrorMaker
+
+Run the Kafka MirrorMaker script from the root Kafka directory using the newly updated configuration files. Make sure to update the path of the config files (or copy them to the root Kafka directory) in the following command.
+
+```bash
+bin/kafka-mirror-maker.sh --consumer.config source-kafka.config --num.streams 1 --producer.config mirror-eventhub.config --whitelist=".*"
+```
+
+To verify that events are making it to the Kafka-enabled Event Hub, check out the ingress statistics in the [Azure portal](https://azure.microsoft.com/features/azure-portal/), or run a consumer against the Event Hub.
+
+Now that MirrorMaker is running, any events sent to the source Kafka cluster should be received by both the Kafka cluster *and* the mirrored Kafka-enabled Event Hub service. By using MirrorMaker and an Event Hubs Kafka endpoint, we can migrate an existing Kafka pipeline to the managed Azure Event Hubs service without changing the existing cluster or interrupting any ongoing data flow!

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -42,6 +42,31 @@ git clone https://github.com/Azure/azure-event-hubs-for-kafka.git
 cd azure-event-hubs-for-kafka/tutorials/oauth/mirror-maker
 ```
 
+## Client Configuration For OAuth
+Kafka clients need to be configured in a way that they can authenticate with Azure Active Directory and fetch OAuth access tokens. These tokens then can be used to get authorized while accessing certain Event Hubs resources.
+
+#### Configure authenticate callback handler of your client so that it can complete auth flow with Azure Active Directory and fetch access tokens
+
+* Set authority for your tenant. Most of the times, this is a URI built with your AAD tenant identifier such as  `"https://login.microsoftonline.com/<tenant-id>/"`
+
+   `this.authority = "<authority>";`
+   
+* Set your AAD application identifier 
+
+   `this.appId = "<app-id>";`
+   
+ * Set your AAD application secret
+ 
+   `this.appSecret = "<app-secret>";`
+
+### Package authentication handler into a jar
+
+Generate the JAR by running mvn command:
+
+```bash
+mvn clean package
+```
+
 ## Set up a Kafka cluster
 
 Use the [Kafka quickstart guide](https://kafka.apache.org/quickstart) to set up a cluster with the desired settings (or use an existing Kafka cluster).
@@ -71,7 +96,7 @@ client.id=mirror_maker_consumer
 
 #### Producer Configuration
 
-Now update the producer config file `mirror-eventhub.config`, which tells MirrorMaker to send the duplicated (or "mirrored") data to the Event Hubs service. Specifically change `bootstrap.servers` and `sasl.jaas.config` to point to your Event Hubs Kafka endpoint. The Event Hubs service requires secure (SASL) communication, which is achieved by setting the last three properties in the configuration below. 
+Now update the producer config file `mirror-eventhub.config`, which tells MirrorMaker to send the duplicated (or "mirrored") data to the Event Hubs service. Specifically change `bootstrap.servers`, `sasl.mechanism`, `sasl.jaas.config`, and `sasl.login.callback.handler.class` to point to your Event Hubs Kafka endpoint. The Event Hubs service requires secure (SASL) communication, which is achieved by setting the last three properties in the configuration below. 
 
 ##### mirror-eventhub.config
 

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -1,8 +1,6 @@
-# Using Apache Kafka's MirrorMaker with Event Hubs for Apache Kafka Ecosystems
+# Using Apache Kafka's MirrorMaker with Event Hubs for Apache Kafka Ecosystems with OAuth
 
-![MirrorMaker Diagram](./mirror-maker-graphic.PNG) 
-
-One major consideration for modern cloud scale apps is being able to update, improve, and change infrastructure without interrupting service. In this tutorial, we show how a Kafka-enabled Event Hub and Kafka MirrorMaker can integrate an existing Kafka pipeline into Azure by "mirroring" the Kafka input stream in the Event Hub service. 
+In this tutorial, we show how a Kafka-enabled Event Hub and Kafka MirrorMaker can integrate an existing Kafka pipeline into Azure by "mirroring" the Kafka input stream in the Event Hub service authorized via OAuth 2.0 flow. 
 
 ## Prerequisites
 
@@ -23,11 +21,17 @@ An Event Hubs namespace is required to send or receive from any Event Hubs servi
 
 ### FQDN
 
-For these samples, you will need the connection string from the portal as well as the FQDN that points to your Event Hub namespace. **The FQDN can be found within your connection string as follows**:
-
-`Endpoint=sb://`**`mynamespace.servicebus.windows.net`**`/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX`
+For these samples, you will need the Fully Qualified Domain Name of you Event Hubs namespace which can be found in Azure Portal. To do so, in Azure Portal, go to your Event Hubs namespace overview page and copy host name which should look like `**`mynamespace.servicebus.windows.net`**`.
 
 If your Event Hubs namespace is deployed on a non-Public cloud, your domain name may differ (e.g. \*.servicebus.chinacloudapi.cn, \*.servicebus.usgovcloudapi.net, or \*.servicebus.cloudapi.de).
+
+## Create an Azure Active Directory Application
+
+In order to run these samples, you will need to create an AAD application with a client secret and assign it as EventHubs Data Owner on the Event Hubs namespace you created in the previous section.
+
+Learn more about [AAD Role Based Access Control](https://docs.microsoft.com/en-us/azure/role-based-access-control/overview)
+
+Learn more about [Azure EventHubs Role Based Access Control](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory)
 
 ## Clone the example project
 

--- a/tutorials/oauth/mirror-maker/README.md
+++ b/tutorials/oauth/mirror-maker/README.md
@@ -21,7 +21,7 @@ An Event Hubs namespace is required to send or receive from any Event Hubs servi
 
 ### FQDN
 
-For these samples, you will need the Fully Qualified Domain Name of you Event Hubs namespace which can be found in Azure Portal. To do so, in Azure Portal, go to your Event Hubs namespace overview page and copy host name which should look like `**`mynamespace.servicebus.windows.net`**`.
+For these samples, you will need the Fully Qualified Domain Name of you Event Hubs namespace which can be found in Azure Portal. To do so, in Azure Portal, go to your Event Hubs namespace overview page and copy host name which should look like `mynamespace.servicebus.windows.net`.
 
 If your Event Hubs namespace is deployed on a non-Public cloud, your domain name may differ (e.g. \*.servicebus.chinacloudapi.cn, \*.servicebus.usgovcloudapi.net, or \*.servicebus.cloudapi.de).
 

--- a/tutorials/oauth/mirror-maker/mirror-eventhub.config
+++ b/tutorials/oauth/mirror-maker/mirror-eventhub.config
@@ -1,0 +1,13 @@
+# Event Hubs Kafka endpoint
+bootstrap.servers=mynamespace.servicebus.windows.net:9093
+client.id=mirror_maker_producer
+
+# Event Hubs requires secure communication
+security.protocol=SASL_SSL
+sasl.mechanism=OAUTHBEARER
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
+
+# to avoid Azure load balancer (4 minutes timeout) closing idle connections
+connections.max.idle.ms=180000
+metadata.max.age.ms=180000

--- a/tutorials/oauth/mirror-maker/pom.xml
+++ b/tutorials/oauth/mirror-maker/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.app</groupId>
+  <artifactId>callbackhandler</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+  <dependencies>
+  	<dependency>
+		<groupId>org.apache.kafka</groupId>
+		<artifactId>kafka_2.12</artifactId>
+		<version>2.3.1</version>
+  	</dependency>
+  	<dependency>
+	    <groupId>com.microsoft.azure</groupId>
+	    <artifactId>msal4j</artifactId>
+	    <version>1.9.0</version>
+	</dependency>
+  </dependencies>
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.2</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tutorials/oauth/mirror-maker/source-kafka.config
+++ b/tutorials/oauth/mirror-maker/source-kafka.config
@@ -1,0 +1,5 @@
+#Simple Kafka set up
+bootstrap.servers={SOURCE.KAFKA.IP.ADDRESS1}:{SOURCE.KAFKA.PORT1},{SOURCE.KAFKA.IP.ADDRESS2}:{SOURCE.KAFKA.PORT2},etc
+client.id=mirror_maker_consumer
+group.id=example-mirrormaker-group
+exclude.internal.topics=true

--- a/tutorials/oauth/mirror-maker/src/main/java/CustomAuthenticateCallbackHandler.java
+++ b/tutorials/oauth/mirror-maker/src/main/java/CustomAuthenticateCallbackHandler.java
@@ -1,0 +1,95 @@
+//Copyright (c) Microsoft Corporation. All rights reserved.
+//Licensed under the MIT License.
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+
+import com.microsoft.aad.msal4j.ClientCredentialFactory;
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.aad.msal4j.IClientCredential;
+
+public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
+
+    final static ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
+    
+    private String authority;
+    private String appId;
+    private String appSecret;
+    private ConfidentialClientApplication aadClient;
+    private ClientCredentialParameters aadParameters;
+
+    @Override
+    public void configure(Map<String, ?> configs, String mechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        String bootstrapServer = Arrays.asList(configs.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)).get(0).toString();
+        bootstrapServer = bootstrapServer.replaceAll("\\[|\\]", "");
+        URI uri = URI.create("https://" + bootstrapServer);
+        String sbUri = uri.getScheme() + "://" + uri.getHost();
+        this.aadParameters = 
+                ClientCredentialParameters.builder(Collections.singleton(sbUri + "/.default"))
+                .build();
+        
+        this.authority = "<authority>";
+        this.appId = "<app-id>";
+        this.appSecret = "<app-secret>";
+    }
+
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (Callback callback: callbacks) {
+            if (callback instanceof OAuthBearerTokenCallback) {
+                try {
+                    OAuthBearerToken token = getOAuthBearerToken();
+                    OAuthBearerTokenCallback oauthCallback = (OAuthBearerTokenCallback) callback;
+                    oauthCallback.token(token);
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    }
+
+    OAuthBearerToken getOAuthBearerToken() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException
+    {
+        if (this.aadClient == null) {
+            synchronized(this) {
+                if (this.aadClient == null) {
+                    IClientCredential credential = ClientCredentialFactory.createFromSecret(this.appSecret);
+                    this.aadClient = ConfidentialClientApplication.builder(this.appId, credential)
+                            .authority(this.authority)
+                            .build();
+                }
+            }
+        }
+        
+        IAuthenticationResult authResult = this.aadClient.acquireToken(this.aadParameters).get();
+        System.out.println("TOKEN ACQUIRED");
+        
+        return new OAuthBearerTokenImp(authResult.accessToken(), authResult.expiresOnDate());
+    }
+
+    public void close() throws KafkaException {
+        // NOOP
+    }
+}

--- a/tutorials/oauth/mirror-maker/src/main/java/OAuthBearerTokenImp.java
+++ b/tutorials/oauth/mirror-maker/src/main/java/OAuthBearerTokenImp.java
@@ -1,0 +1,43 @@
+//Copyright (c) Microsoft Corporation. All rights reserved.
+//Licensed under the MIT License.
+
+import java.util.Date;
+import java.util.Set;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+
+public class OAuthBearerTokenImp implements OAuthBearerToken
+{
+    String token;
+    long lifetimeMs;
+    
+    public OAuthBearerTokenImp(final String token, Date expiresOn) {
+        this.token = token;
+        this.lifetimeMs = expiresOn.getTime();
+    }
+    
+    @Override
+    public String value() {
+        return this.token;
+    }
+
+    @Override
+    public Set<String> scope() {
+        return null;
+    }
+
+    @Override
+    public long lifetimeMs() {
+        return this.lifetimeMs;
+    }
+
+    @Override
+    public String principalName() {
+        return null;
+    }
+
+    @Override
+    public Long startTimeMs() {
+        return null;
+    }
+}


### PR DESCRIPTION
Adding new sample demonstrating how to configure mirror-maker clients to write to Azure Event Hubs Kafka endpoints with OAUTHBEARER SASL mechanism.