### PR TITLE
Bumping Java Jar releases in OAuth App Secret example along with some code linting.

### DIFF
--- a/tutorials/oauth/java/appsecret/README.md
+++ b/tutorials/oauth/java/appsecret/README.md
@@ -22,7 +22,7 @@ An Event Hubs namespace is required to send or receive from any Event Hubs servi
 
 ### FQDN
 
-For these samples, you will need the Fully Qualified Domain Name of you Event Hubs namespace which can be found in Azure Portal. To do so, in Azure Portal, go to your Event Hubs namespace overview page and copy host name which should look like `**`mynamespace.servicebus.windows.net`**`.
+For these samples, you will need the Fully Qualified Domain Name of you Event Hubs namespace which can be found in Azure Portal. To do so, in Azure Portal, go to your Event Hubs namespace overview page and copy host name which should look like `**`<your-namespace>.servicebus.windows.net`**`.
 
 If your Event Hubs namespace is deployed on a non-Public cloud, your domain name may differ (e.g. \*.servicebus.chinacloudapi.cn, \*.servicebus.usgovcloudapi.net, or \*.servicebus.cloudapi.de).
 
@@ -56,21 +56,21 @@ Kafka clients need to be configured in a way that they can authenticate with Azu
    `sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;`
 * Set login callback handler. This is the authentication handler which is responsible to complete oauth flow and return an access token.
 
-   `sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;`
+   `sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler`
 
 #### Configure authenticate callback handler of your client so that it can complete auth flow with Azure Active Directory and fetch access tokens
 
 * Set authority for your tenant. Most of the times, this is a URI built with your AAD tenant identifier such as  `"https://login.microsoftonline.com/<tenant-id>/"`
 
-   `this.authority = "<authority>";`
-   
-* Set your AAD application identifier 
+   `this.authority = "https://login.microsoftonline.com/<tenant-id>/";`
+
+* Set your AAD application identifier, also known as client id
 
    `this.appId = "<app-id>";`
-   
- * Set your AAD application secret
- 
-   `this.appSecret = "<app-secret>";`
+
+ * Set your AAD application password, also known as client secret
+
+   `this.appSecret = "<app-password>";`
 
 ## Producer
 
@@ -87,7 +87,7 @@ bootstrap.servers=mynamespace.servicebus.windows.net:9093 # REPLACE
 security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
-sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
 ```
 
 ### Run producer from command line
@@ -101,7 +101,7 @@ mvn clean package
 mvn exec:java -Dexec.mainClass="TestProducer"
 ```
 
-The producer will now begin sending events to the Kafka-enabled Event Hub at topic `test` (or whatever topic you chose) and printing the events to stdout. 
+The producer will now begin sending events to the Kafka-enabled Event Hub at topic `test` (or whatever topic you chose) and printing the events to stdout.
 
 ## Consumer
 
@@ -120,7 +120,7 @@ request.timeout.ms=60000
 security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
-sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
 ```
 
 ### Run consumer from command line

--- a/tutorials/oauth/java/appsecret/consumer/pom.xml
+++ b/tutorials/oauth/java/appsecret/consumer/pom.xml
@@ -1,29 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>com.example.app</groupId>
   <artifactId>event-hubs-kafka-java-consumer</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   <dependencies>
-  	<dependency>
-		<groupId>org.apache.kafka</groupId>
-		<artifactId>kafka_2.12</artifactId>
-		<version>2.3.1</version>
-  	</dependency>
-  	<dependency>
-	    <groupId>com.microsoft.azure</groupId>
-	    <artifactId>msal4j</artifactId>
-	    <version>1.0.0</version>
-	</dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>msal4j</artifactId>
+      <version>1.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.6.1</version>
+    </dependency>
   </dependencies>
   <build>
     <defaultGoal>install</defaultGoal>
@@ -47,5 +59,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/tutorials/oauth/java/appsecret/consumer/src/main/java/CustomAuthenticateCallbackHandler.java
+++ b/tutorials/oauth/java/appsecret/consumer/src/main/java/CustomAuthenticateCallbackHandler.java
@@ -16,7 +16,6 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
@@ -32,7 +31,7 @@ import com.microsoft.aad.msal4j.IClientCredential;
 public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
 
     final static ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
-    
+
     private String authority;
     private String appId;
     private String appSecret;
@@ -45,13 +44,13 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
         bootstrapServer = bootstrapServer.replaceAll("\\[|\\]", "");
         URI uri = URI.create("https://" + bootstrapServer);
         String sbUri = uri.getScheme() + "://" + uri.getHost();
-        this.aadParameters = 
+        this.aadParameters =
                 ClientCredentialParameters.builder(Collections.singleton(sbUri + "/.default"))
                 .build();
-        
-        this.authority = "<authority>";
-        this.appId = "<app-id>";
-        this.appSecret = "<app-secret>";
+
+        this.authority = "https://login.microsoftonline.com/<tenant-id>/"; // replace <tenant-id> with your tenant id
+        this.appId = "<application-id>"; // also called client id
+        this.appSecret = "<application-password>"; // also called client secret
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -82,10 +81,10 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
                 }
             }
         }
-        
+
         IAuthenticationResult authResult = this.aadClient.acquireToken(this.aadParameters).get();
         System.out.println("TOKEN ACQUIRED");
-        
+
         return new OAuthBearerTokenImp(authResult.accessToken(), authResult.expiresOnDate());
     }
 

--- a/tutorials/oauth/java/appsecret/consumer/src/main/java/OAuthBearerTokenImp.java
+++ b/tutorials/oauth/java/appsecret/consumer/src/main/java/OAuthBearerTokenImp.java
@@ -9,12 +9,12 @@ public class OAuthBearerTokenImp implements OAuthBearerToken
 {
     String token;
     long lifetimeMs;
-    
+
     public OAuthBearerTokenImp(final String token, Date expiresOn) {
         this.token = token;
         this.lifetimeMs = expiresOn.getTime();
     }
-    
+
     @Override
     public String value() {
         return this.token;

--- a/tutorials/oauth/java/appsecret/consumer/src/main/java/TestConsumerThread.java
+++ b/tutorials/oauth/java/appsecret/consumer/src/main/java/TestConsumerThread.java
@@ -1,18 +1,25 @@
 //Copyright (c) Microsoft Corporation. All rights reserved.
 //Licensed under the MIT License.
-import org.apache.kafka.clients.consumer.*;
-import org.apache.kafka.common.serialization.LongDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import java.io.FileReader;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 
 public class TestConsumerThread implements Runnable {
 
     private final String TOPIC;
-    
+
     //Each consumer needs a unique client ID per thread
     private static int id = 0;
 
@@ -26,7 +33,7 @@ public class TestConsumerThread implements Runnable {
 
         try {
             while (true) {
-                final ConsumerRecords<Long, String> consumerRecords = consumer.poll(1000);
+                final ConsumerRecords<Long, String> consumerRecords = consumer.poll(Duration.ofMillis(1000));
                 for(ConsumerRecord<Long, String> cr : consumerRecords) {
                     System.out.printf("Consumer Record:(%d, %s, %d, %d)\n", cr.key(), cr.value(), cr.partition(), cr.offset());
                 }
@@ -58,7 +65,7 @@ public class TestConsumerThread implements Runnable {
             // Subscribe to the topic.
             consumer.subscribe(Collections.singletonList(TOPIC));
             return consumer;
-            
+
         } catch (FileNotFoundException e){
             System.out.println("FileNoteFoundException: " + e);
             System.exit(1);

--- a/tutorials/oauth/java/appsecret/consumer/src/main/resources/consumer.config
+++ b/tutorials/oauth/java/appsecret/consumer/src/main/resources/consumer.config
@@ -1,7 +1,7 @@
-bootstrap.servers=mynamespace.servicebus.windows.net:9093
+bootstrap.servers=<your-namespace>.servicebus.windows.net:9093
 group.id=$Default
 request.timeout.ms=60000
 security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
-sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler

--- a/tutorials/oauth/java/appsecret/producer/pom.xml
+++ b/tutorials/oauth/java/appsecret/producer/pom.xml
@@ -14,16 +14,31 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   <dependencies>
-  	<dependency>
-		<groupId>org.apache.kafka</groupId>
-		<artifactId>kafka_2.12</artifactId>
-		<version>2.3.1</version>
-  	</dependency>
-  	<dependency>
-	    <groupId>com.microsoft.azure</groupId>
-	    <artifactId>msal4j</artifactId>
-	    <version>1.0.0</version>
-	</dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>msal4j</artifactId>
+      <version>1.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.6.1</version>
+    </dependency>
   </dependencies>
   <build>
     <defaultGoal>install</defaultGoal>
@@ -47,5 +62,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/tutorials/oauth/java/appsecret/producer/src/main/java/CustomAuthenticateCallbackHandler.java
+++ b/tutorials/oauth/java/appsecret/producer/src/main/java/CustomAuthenticateCallbackHandler.java
@@ -16,23 +16,22 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
-
 import com.microsoft.aad.msal4j.ClientCredentialFactory;
 import com.microsoft.aad.msal4j.ClientCredentialParameters;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.IClientCredential;
 
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+
 public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
 
     final static ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
-    
+
     private String authority;
     private String appId;
     private String appSecret;
@@ -45,13 +44,13 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
         bootstrapServer = bootstrapServer.replaceAll("\\[|\\]", "");
         URI uri = URI.create("https://" + bootstrapServer);
         String sbUri = uri.getScheme() + "://" + uri.getHost();
-        this.aadParameters = 
+        this.aadParameters =
                 ClientCredentialParameters.builder(Collections.singleton(sbUri + "/.default"))
                 .build();
-        
-        this.authority = "<authority>";
-        this.appId = "<app-id>";
-        this.appSecret = "<app-secret>";
+
+        this.authority = "https://login.microsoftonline.com/<tenant-id>/"; // replace <tenant-id> with your tenant id
+        this.appId = "<app-id>"; // also called client id
+        this.appSecret = "<app-password>"; // also called client secret
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -82,10 +81,10 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
                 }
             }
         }
-        
+
         IAuthenticationResult authResult = this.aadClient.acquireToken(this.aadParameters).get();
         System.out.println("TOKEN ACQUIRED");
-        
+
         return new OAuthBearerTokenImp(authResult.accessToken(), authResult.expiresOnDate());
     }
 

--- a/tutorials/oauth/java/appsecret/producer/src/main/java/OAuthBearerTokenImp.java
+++ b/tutorials/oauth/java/appsecret/producer/src/main/java/OAuthBearerTokenImp.java
@@ -9,12 +9,12 @@ public class OAuthBearerTokenImp implements OAuthBearerToken
 {
     String token;
     long lifetimeMs;
-    
+
     public OAuthBearerTokenImp(final String token, Date expiresOn) {
         this.token = token;
         this.lifetimeMs = expiresOn.getTime();
     }
-    
+
     @Override
     public String value() {
         return this.token;

--- a/tutorials/oauth/java/appsecret/producer/src/main/java/TestDataReporter.java
+++ b/tutorials/oauth/java/appsecret/producer/src/main/java/TestDataReporter.java
@@ -4,7 +4,6 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import java.sql.Timestamp;
 
 public class TestDataReporter implements Runnable {
 
@@ -20,10 +19,10 @@ public class TestDataReporter implements Runnable {
 
     @Override
     public void run() {
-        for(int i = 0; i < NUM_MESSAGES; i++) {                
+        for(int i = 0; i < NUM_MESSAGES; i++) {
             long time = System.currentTimeMillis();
             System.out.println("Test Data #" + i + " from thread #" + Thread.currentThread().getId());
-            
+
             final ProducerRecord<Long, String> record = new ProducerRecord<Long, String>(TOPIC, time, "Test Data #" + i);
             producer.send(record, new Callback() {
                 public void onCompletion(RecordMetadata metadata, Exception exception) {

--- a/tutorials/oauth/java/appsecret/producer/src/main/java/TestProducer.java
+++ b/tutorials/oauth/java/appsecret/producer/src/main/java/TestProducer.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Executors;
 public class TestProducer {
     //Change constant to send messages to the desired topic, for this example we use 'test'
     private final static String TOPIC = "test";
-        
+
     private final static int NUM_THREADS = 1;
 
 
@@ -40,7 +40,7 @@ public class TestProducer {
         } catch (Exception e){
             System.out.println("Failed to create producer with exception: " + e);
             System.exit(0);
-            return null;        //unreachable
+            return null; //unreachable
         }
     }
 }

--- a/tutorials/oauth/java/appsecret/producer/src/main/resources/producer.config
+++ b/tutorials/oauth/java/appsecret/producer/src/main/resources/producer.config
@@ -1,5 +1,5 @@
-bootstrap.servers=mynamespace.servicebus.windows.net:9093
+bootstrap.servers=<your-namespace>.servicebus.windows.net:9093
 security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
-sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler


### PR DESCRIPTION
- Organized some imports.
- Added some small changes to the config file as semicolons in callback class.
- Bumped Kafka client jars and changed polling with `Duration` as `long` was deprecated in release 2.x
- Improved some contents of ther README.md to satisfy nomenclature differences from OAUTH and Azure AD.
- Tweaked a bit on expected values to better inform the end user on how params were to be added to Callbacks (Consumer/Producer).