### PR TITLE
Update Logstash tutorial to reference integration plugin

### DIFF
--- a/tutorials/logstash/README.md
+++ b/tutorials/logstash/README.md
@@ -13,7 +13,7 @@ In addition:
 * [Logstash](https://www.elastic.co/guide/en/logstash/current/installing-logstash.html)
     * Unpack the download file and add the Logstash binaries directory, e.g. `<unpacked_file_path>/logstash-6.6.1/bin`, to your `PATH` environment variable.
     * Kafka input/output plugins, `logstash-input-kafka` and `logstash-output-kafka`, are ususlly already included in common plugins, which you can use directly. You can verify whether they are appropriately installed by running `logstash-plugin list 'kafka'`.
-    * In case of the above plugins not included in common plugins, you can run `logstash-plugin install logstash-input-kafka` or `logstash-plugin install logstash-output-kafka` to install Kafka input/output plugins.
+    * In case of the above plugins not included in common plugins, you can run `logstash-plugin install logstash-integration-kafka` to install the Kafka integration that includes input/output plugins.
 * [Git](https://www.git-scm.com/downloads)
 
 ## Create an Event Hubs namespace


### PR DESCRIPTION
The Logstash input and output plugins for Kafka are now provided by [a single "integration" plugin](https://www.elastic.co/guide/en/logstash/current/plugins-integrations-kafka.html), and the previous stand-alone plugins are no longer maintained. By including instructions for the integration we encourage our users to get the latest version that includes fixes and updates.

Integration plugins require Logstash 6.5+ (released 2018-11), and the oldest non-EOL version of Logstash as of this writing is 7.17.