### PR TITLE
Fix formatting and update demo files for GitHub Security features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,63 @@
+# GHAS Demo Files — Sargent & Lundy
+
+These files demonstrate GitHub Advanced Security features. **Do NOT use any credentials in this folder in production.**
+
+## Demo Scenarios
+
+### 1. Push Protection Demo
+**File:** `push-protection-test.sh`
+
+Try pushing this branch with the fake secret in the file. GitHub will block the push with:
+```
+error GH009: Secrets detected! This push failed.
+```
+
+**Steps:**
+1. Stage and commit the file: `git add . && git commit -m "add config"`
+2. Push: `git push origin demo/ghas-security-features`
+3. Observe push protection blocking the commit
+4. Show the bypass workflow option
+
+---
+
+### 2. Secret Scanning Demo
+**File:** `vulnerable-config.env`
+
+This file contains test secrets that secret scanning will detect after they're in the repo:
+- AWS-style access key
+- Generic API token pattern
+
+After the push (if bypassed or on a repo without push protection), go to:
+**Security tab → Secret scanning alerts**
+
+---
+
+### 3. PR Annotation / Code Scanning Demo
+**File:** `VulnerableController.cs`
+
+This C# file has intentional vulnerabilities that CodeQL will detect:
+- **SQL Injection** — string concatenation in a SQL query
+- **Cross-Site Scripting (XSS)** — unsanitized user input in HTML response
+- **Path Traversal** — unsanitized file path from user input
+
+**Steps:**
+1. Push this branch
+2. Open a Pull Request to `main`
+3. CodeQL runs via the workflow in `.github/workflows/codeql-analysis.yml`
+4. Findings appear as **inline PR annotations** with Copilot Autofix suggestions
+
+---
+
+### 4. CodeQL Workflow
+**File:** `.github/workflows/codeql-analysis.yml`
+
+A minimal CodeQL workflow for C# that runs on PRs and pushes. This enables code scanning alerts and PR annotations.
+
+---
+
+## Cleanup
+After the demo, delete this branch:
+```bash
+git branch -D demo/ghas-security-features
+git push origin --delete demo/ghas-security-features
+```

--- a/demo/VulnerableController.cs
+++ b/demo/VulnerableController.cs
@@ -1,0 +1,76 @@
+// ============================================================
+// DEMO ONLY — Vulnerable Controller for Code Scanning Demo
+// These vulnerabilities are INTENTIONAL to show CodeQL alerts
+// and PR annotations with Copilot Autofix suggestions.
+// ============================================================
+
+using Microsoft.AspNetCore.Mvc;
+using System.Data.SqlClient;
+using System.IO;
+
+namespace ContosoUniversity.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class VulnerableController : ControllerBase
+    {
+        private readonly string _connectionString;
+
+        public VulnerableController(IConfiguration config)
+        {
+            _connectionString = config.GetConnectionString("DefaultConnection");
+        }
+
+        // -------------------------------------------------------
+        // VULNERABILITY 1: SQL Injection
+        // CodeQL will flag string concatenation in SQL queries.
+        // CWE-89 — Improper Neutralization of SQL input
+        // -------------------------------------------------------
+        [HttpGet("students")]
+        public IActionResult SearchStudents(string name)
+        {
+            var results = new List<string>();
+
+            using var connection = new SqlConnection(_connectionString);
+            connection.Open();
+
+            // BAD: User input concatenated directly into SQL query
+            string query = "SELECT * FROM Students WHERE LastName = '" + name + "'";
+            using var command = new SqlCommand(query, connection);
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add(reader["LastName"].ToString());
+            }
+
+            return Ok(results);
+        }
+
+        // -------------------------------------------------------
+        // VULNERABILITY 2: Cross-Site Scripting (XSS)
+        // CodeQL will flag unsanitized user input in HTML response.
+        // CWE-79 — Improper Neutralization of Input During Web Page Generation
+        // -------------------------------------------------------
+        [HttpGet("greeting")]
+        public IActionResult Greeting(string username)
+        {
+            // BAD: User input written directly into HTML without encoding
+            return Content("<html><body><h1>Hello, " + username + "!</h1></body></html>", "text/html");
+        }
+
+        // -------------------------------------------------------
+        // VULNERABILITY 3: Path Traversal
+        // CodeQL will flag unsanitized file path from user input.
+        // CWE-22 — Improper Limitation of a Pathname to a Restricted Directory
+        // -------------------------------------------------------
+        [HttpGet("download")]
+        public IActionResult DownloadFile(string fileName)
+        {
+            // BAD: User input used directly in file path without validation
+            var filePath = Path.Combine("/app/uploads", fileName);
+            var fileBytes = System.IO.File.ReadAllBytes(filePath);
+            return File(fileBytes, "application/octet-stream", fileName);
+        }
+    }
+}

--- a/demo/push-protection-test.sh
+++ b/demo/push-protection-test.sh
@@ -9,3 +9,6 @@ export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLEBN"
 export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEYGHHG"
 
 echo "Connecting to database..."
+
+# Additional test secret — GitHub Personal Access Token
+export GITHUB_TOKEN="ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12"

--- a/demo/push-protection-test.sh
+++ b/demo/push-protection-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# ============================================================
+# DEMO ONLY — Push Protection Test
+# This file contains a fake secret to trigger push protection.
+# ============================================================
+
+# This fake AWS key will trigger GitHub push protection
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLEB"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEYGHHG"
+
+echo "Connecting to database..."

--- a/demo/push-protection-test.sh
+++ b/demo/push-protection-test.sh
@@ -5,7 +5,7 @@
 # ============================================================
 
 # This fake AWS key will trigger GitHub push protection
-export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLEB"
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLEBN"
 export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEYGHHG"
 
 echo "Connecting to database..."

--- a/demo/vulnerable-config.env
+++ b/demo/vulnerable-config.env
@@ -1,0 +1,19 @@
+# ============================================================
+# DEMO ONLY — Secret Scanning Test
+# These are FAKE credentials to demonstrate secret scanning.
+# ============================================================
+
+# Fake GitHub Personal Access Token (classic format)
+GITHUB_PAT_TOKEN=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
+
+# Fake Azure Storage connection string
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=sldemostorage;AccountKey=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV==;EndpointSuffix=core.windows.net
+
+# Fake Slack webhook
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+
+# Fake SendGrid API key
+SENDGRID_API_KEY=SG.abcdefghijklmnopqrstuvwx.yz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab
+
+# Fake generic database connection
+DB_CONNECTION_STRING=Server=sql-prod.database.windows.net;Database=ContosoDB;User Id=admin;Password=P@ssw0rd!2026;

--- a/demo/vulnerable-config.env
+++ b/demo/vulnerable-config.env
@@ -4,7 +4,7 @@
 # ============================================================
 
 # Fake GitHub Personal Access Token (classic format)
-GITHUB_PAT_TOKEN=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
+GITHUB_PAT_TOKEN=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m
 
 # Fake Azure Storage connection string
 AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=sldemostorage;AccountKey=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV==;EndpointSuffix=core.windows.net


### PR DESCRIPTION
This pull request introduces a new demo folder and supporting files to showcase GitHub Advanced Security (GHAS) features, including push protection, secret scanning, and code scanning with CodeQL. It provides demo scripts, intentionally vulnerable code, and documentation to guide users through various security scenarios. Additionally, a basic Dependabot configuration is added.

**Demo and Documentation Additions:**

* Added a comprehensive `README.md` in the `demo` folder describing four demo scenarios: push protection, secret scanning, PR annotation/code scanning, and CodeQL workflow, along with cleanup instructions.

* Introduced `push-protection-test.sh` containing fake AWS credentials designed to trigger GitHub push protection during demo workflows.

* Added `vulnerable-config.env` with multiple fake secrets (GitHub PAT, Azure, Slack, SendGrid, DB connection) to demonstrate secret scanning alerts.

* Created `VulnerableController.cs`, a C# controller with intentional vulnerabilities (SQL Injection, XSS, Path Traversal) for CodeQL/code scanning demo purposes.

**Tooling and Automation:**

* Added a starter `.github/dependabot.yml` configuration file to enable Dependabot version updates on a weekly schedule.